### PR TITLE
Changed path to existing GPIO class on new kernel

### DIFF
--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -13,7 +13,7 @@ var rev = fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(functio
 })[0].split(":")[1].trim();
 
 // tests the device tree directory to determine the actual gpio path
-if (fs.existsSync('/sys/devices/soc')) {
+if (fs.existsSync(sysFsPathNew)) {
 	sysFsPath = sysFsPathNew;
 } else {
 	sysFsPath = sysFsPathOld; // fallback for old kernels


### PR DESCRIPTION
On the new kernel, the path '/sys/devices/soc' does not exist, so wrong path to GPIO was used on Raspberry Pi 2. By checking if the actual folder exists, this problem is solved.
